### PR TITLE
rework mqtt topic tree and json structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,17 @@ The parameter.json contains all devices and the corresponding properties for the
 
 ism7mqtt initially fetches all properties declared in parameter.json and afterwards subscribes to changes with an intervall of 60 seconds. Whenever new values are received from ism7 a json update with all those properties is published to mqtt. Please be aware that an update contains only the changed properties - so only the initial message may contain all properties.
 
+You can also enable separate topics (`--separate`), which will report each value in its own nested topic, and disable the json output (`--disable.json`) if you don't need it.
+
 Each device on the bus (and present in the parameter.json) is reported via its own topic. The format is
 
 ```txt
 Wolf/<ism7 ip address>/<device type>_<device bus address>
 ```
 
-For each property of type ListParameter (basically all comboboxes) two values are reported - the original numerical value and the german text representation (with the suffix `_Text`).
+For each property of type ListParameter (basically all comboboxes) nested values are reported - the original numerical value (`value`) and the german text representation (`text`).
 
-Duplicate properties get a numerical suffix (property id) to make them unique.
+Duplicate properties are reported as a sub property or topic with their numerical identifier (property id) to make them unique.
 
 ## Writing
 
@@ -52,13 +54,49 @@ You can send values to ism7 via mqtt by publishing json to the topic
 Wolf/<ism7 ip address>/<device type>_<device bus address>/set
 ```
 
-or just the raw value to
+The payload has the same structure as the published json - you can even set multiple values in one request.
+
+You can also publish single values to the corresponding MQTT topic:
 
 ```txt
-Wolf/<ism7 ip address>/<device type>_<device bus address>/set/<property name>
+Wolf/<ism7 ip address>/<device type>_<device bus address>/set/<property name>/...
 ```
 
-Please be aware that not all properties can be set - ism7mqtt tries to validate if a property is writable, but this may be incorrect (#6).
+If the property is nested, just append the parts to the end.
+
+So for a duplicate ListParameter publish either json to `Wolf/<ism7 ip address>/WWSystem_BM-2_0x35/set`
+
+```json
+{
+    "Programmwahl": {
+        "35012":{
+            "value":1
+        }
+    }
+}
+```
+
+or
+
+```json
+{
+    "Programmwahl": {
+        "35012":{
+            "text":"Auto"
+        }
+    }
+}
+```
+
+or the values to the topics
+
+```txt
+Wolf/<ism7 ip address>/WWSystem_BM-2_0x35/set/Programmwahl/35012/value
+or
+Wolf/<ism7 ip address>/WWSystem_BM-2_0x35/set/Programmwahl/35012/text
+```
+
+Please be aware that not all properties can be set - ism7mqtt tries to validate if a property is writable, but this may be incorrect.
 
 ## Bugs / Missing Features
 

--- a/src/ism7mqtt/ISM7/Ism7Client.cs
+++ b/src/ism7mqtt/ISM7/Ism7Client.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
@@ -87,10 +88,19 @@ namespace ism7mqtt
 
         public async Task OnCommandAsync(string mqttTopic, JsonObject data, CancellationToken cancellationToken)
         {
-            var writeRequests = _config.GetWriteRequest(mqttTopic, data).ToList();
+            List<InfoWrite> writeRequests;
+            try
+            {
+                writeRequests = _config.GetWriteRequest(mqttTopic, data).ToList();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"error for topic '{mqttTopic}' with payload '{data.ToJsonString()}'\n{ex.Message}");
+                return;
+            }
             if (writeRequests.Count == 0)
             {
-                Console.WriteLine($"nothing to send for topic '{mqttTopic}'");
+                Console.WriteLine($"nothing to send for topic '{mqttTopic}' with payload '{data.ToJsonString()}'");
                 return;
             }
             var request = new TelegramBundleReq

--- a/src/ism7mqtt/ISM7/Ism7Client.cs
+++ b/src/ism7mqtt/ISM7/Ism7Client.cs
@@ -10,11 +10,11 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt
 {
@@ -85,7 +85,7 @@ namespace ism7mqtt
             return ssl;
         }
 
-        public async Task OnCommandAsync(string mqttTopic, JObject data, CancellationToken cancellationToken)
+        public async Task OnCommandAsync(string mqttTopic, JsonObject data, CancellationToken cancellationToken)
         {
             var writeRequests = _config.GetWriteRequest(mqttTopic, data).ToList();
             if (writeRequests.Count == 0)

--- a/src/ism7mqtt/ISM7/Ism7Config.cs
+++ b/src/ism7mqtt/ISM7/Ism7Config.cs
@@ -217,10 +217,7 @@ namespace ism7mqtt
                     foreach (var converter in converters)
                     {
                         var parameter = _parameter[converter.CTID];
-                        foreach (var value in parameter.GetValues(converter))
-                        {
-                            result.AddProperty(value);
-                        }
+                        result.AddProperty(parameter.GetValues(converter));
                     }
                     return result;
                 }

--- a/src/ism7mqtt/ISM7/Xml/BM2DateConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/BM2DateConverterTemplate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -20,14 +20,14 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _value.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
-            var result = new JValue(_value.Value);
+            var result = JsonValue.Create(_value.Value);
             _value = null;
             return result;
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/BM2TimeConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/BM2TimeConverterTemplate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -16,14 +16,14 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _value.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
-            var result = new JValue(_value.Value);
+            var result = JsonValue.Create(_value.Value);
             _value = null;
             return result;
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/BinaryReadOnlyConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/BinaryReadOnlyConverterTemplate.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -24,16 +24,16 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _bit.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             if (!HasValue)
                 throw new InvalidOperationException();
-            var result = new JValue(_bit.Value == OnValue);
+            var result = JsonValue.Create(_bit.Value == OnValue);
             _bit = null;
             return result;
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/Bit0to3ConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/Bit0to3ConverterTemplate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -18,16 +18,16 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _value.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             if (!HasValue)
                 throw new InvalidOperationException();
-            var result = new JValue(_value.Value);
+            var result = JsonValue.Create(_value.Value);
             _value = null;
             return result;
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/Bit4to7ConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/Bit4to7ConverterTemplate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -18,16 +18,16 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _value.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             if (!HasValue)
                 throw new InvalidOperationException();
-            var result = new JValue(_value.Value);
+            var result = JsonValue.Create(_value.Value);
             _value = null;
             return result;
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/ConverterTemplateBase.cs
+++ b/src/ism7mqtt/ISM7/Xml/ConverterTemplateBase.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -19,8 +19,8 @@ namespace ism7mqtt.ISM7.Xml
 
         public abstract bool HasValue { get; }
 
-        public abstract JValue GetValue();
+        public abstract JsonValue GetValue();
 
-        public abstract IEnumerable<InfoWrite> GetWrite(JValue value);
+        public abstract IEnumerable<InfoWrite> GetWrite(JsonValue value);
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/DateTimeConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/DateTimeConverterTemplate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -14,12 +14,12 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => false;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/ListParameterDescriptor.cs
+++ b/src/ism7mqtt/ISM7/Xml/ListParameterDescriptor.cs
@@ -23,26 +23,23 @@ namespace ism7mqtt.ISM7.Xml
         [XmlElement("DependentDefinitionId")]
         public string DependentDefinitionId { get; set; }
 
-        public override IEnumerable<KeyValuePair<string,JsonNode>> GetValues(ConverterTemplateBase converter)
+        public override KeyValuePair<string,JsonNode> GetValues(ConverterTemplateBase converter)
         {
             var value = converter.GetValue();
-            yield return new KeyValuePair<string,JsonNode>(SafeName, value);
-            if (String.IsNullOrEmpty(KeyValueList)) yield break;
+            var result = new KeyValuePair<string, JsonNode>(SafeName, value);
+            if (String.IsNullOrEmpty(KeyValueList)) return result;
             var names = KeyValueList.Split(';');
             var key = value.ToString();
-            var index = Array.IndexOf<string>(names, key);
-            if (index < 0) yield break;
+            var index = Array.IndexOf(names, key);
+            if (index < 0) return result;
             index++;
-            if (index >= names.Length) yield break;
-            yield return new KeyValuePair<string,JsonNode>($"{SafeName}_Text", names[index]);
-        }
-
-        public IEnumerable<string> Values
-        {
-            get
+            if (index >= names.Length) return result;
+            var data = new JsonObject
             {
-                return KeyValueList.Split(';').Where((x, i) => i % 2 == 1);
-            }
+                ["value"] = value,
+                ["text"] = names[index]
+            };
+            return new KeyValuePair<string, JsonNode>(SafeName, data);
         }
 
         public JsonValue GetValue(JsonValue value)

--- a/src/ism7mqtt/ISM7/Xml/ListParameterDescriptor.cs
+++ b/src/ism7mqtt/ISM7/Xml/ListParameterDescriptor.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Serialization;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -23,18 +23,18 @@ namespace ism7mqtt.ISM7.Xml
         [XmlElement("DependentDefinitionId")]
         public string DependentDefinitionId { get; set; }
 
-        public override IEnumerable<JProperty> GetValues(ConverterTemplateBase converter)
+        public override IEnumerable<KeyValuePair<string,JsonNode>> GetValues(ConverterTemplateBase converter)
         {
             var value = converter.GetValue();
-            yield return new JProperty(SafeName, value);
+            yield return new KeyValuePair<string,JsonNode>(SafeName, value);
             if (String.IsNullOrEmpty(KeyValueList)) yield break;
             var names = KeyValueList.Split(';');
             var key = value.ToString();
-            var index = Array.IndexOf(names, key);
+            var index = Array.IndexOf<string>(names, key);
             if (index < 0) yield break;
             index++;
             if (index >= names.Length) yield break;
-            yield return new JProperty($"{SafeName}_Text", names[index]);
+            yield return new KeyValuePair<string,JsonNode>($"{SafeName}_Text", names[index]);
         }
 
         public IEnumerable<string> Values
@@ -45,15 +45,15 @@ namespace ism7mqtt.ISM7.Xml
             }
         }
 
-        public JValue GetValue(JValue value)
+        public JsonValue GetValue(JsonValue value)
         {
             if (String.IsNullOrEmpty(KeyValueList)) return value;
             var names = KeyValueList.Split(';');
-            var name = value.Value.ToString();
+            var name = value.ToString();
             var index = Array.IndexOf(names, name);
             if (index < 1 || index % 2 == 0) return value;
             index--;
-            return new JValue(names[index]);
+            return JsonValue.Create(names[index]);
         } 
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/MixerStateConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/MixerStateConverterTemplate.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -34,27 +34,27 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _open.HasValue && _close.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
-            JValue result;
+            JsonValue result;
             if (_open.HasValue && _open.Value != 0)
             {
-                result = new JValue("opened");
+                result = JsonValue.Create("opened");
             }
             else if (_close.HasValue && _close.Value != 0)
             {
-                result = new JValue("closed");
+                result = JsonValue.Create("closed");
             }
             else
             {
-                result = new JValue("-");
+                result = JsonValue.Create("-");
             }
             _open = null;
             _close = null;
             return result;
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/NullConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/NullConverterTemplate.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -23,12 +23,12 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => false;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/NumericConverter16Template.cs
+++ b/src/ism7mqtt/ISM7/Xml/NumericConverter16Template.cs
@@ -66,28 +66,35 @@ namespace ism7mqtt.ISM7.Xml
             switch (Type)
             {
                 case "US":
-                    data = value.GetValue<UInt16>();
+                    if (!UInt16.TryParse(value.ToString(), out data)) yield break;
                     break;
                 case "SS":
-                    data = (ushort) value.GetValue<short>();
+                    if (!Int16.TryParse(value.ToString(), out var int16)) yield break;
+                    data = (ushort) int16;
                     break;
                 case "SS10":
-                    data = (ushort) (value.GetValue<double>() * 10);
+                    if (!Double.TryParse(value.ToString(), out var parsed)) yield break;
+                    data = (ushort) (parsed * 10);
                     break;
                 case "US10":
-                    data = (ushort) (value.GetValue<double>() * 10);
+                    if (!Double.TryParse(value.ToString(), out parsed)) yield break;
+                    data = (ushort) (parsed * 10);
                     break;
                 case "SS100":
-                    data = (ushort) (value.GetValue<double>() * 100);
+                    if (!Double.TryParse(value.ToString(), out parsed)) yield break;
+                    data = (ushort) (parsed * 100);
                     break;
                 case "SSPR":
-                    data = (ushort) (value.GetValue<double>() * (1.0/256));
+                    if (!Double.TryParse(value.ToString(), out parsed)) yield break;
+                    data = (ushort) (parsed * (1.0/256));
                     break;
                 case "US4":
-                    data = (ushort) (value.GetValue<double>() * 4);
+                    if (!Double.TryParse(value.ToString(), out parsed)) yield break;
+                    data = (ushort) (parsed * 4);
                     break;
                 case "IntDiv60":
-                    data = (ushort) (value.GetValue<double>() * 60);
+                    if (!Double.TryParse(value.ToString(), out parsed)) yield break;
+                    data = (ushort) (parsed * 60);
                     break;
                 default:
                     throw new NotImplementedException($"type '{Type}' for CTID '{CTID}' is not yet implemented");

--- a/src/ism7mqtt/ISM7/Xml/NumericConverter16Template.cs
+++ b/src/ism7mqtt/ISM7/Xml/NumericConverter16Template.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -16,43 +16,43 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _value.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             if (!HasValue)
                 throw new InvalidOperationException();
-            JValue result;
+            JsonValue result;
             switch (Type)
             {
                 case "US":
-                    result = new JValue(_value.Value);
+                    result = JsonValue.Create(_value.Value);
                     _value = null;
                     return result;
                 case "SS":
-                    result = new JValue((short)_value.Value);
+                    result = JsonValue.Create((short)_value.Value);
                     _value = null;
                     return result;
                 case "SS10":
-                    result = new JValue(((short)_value.Value) / 10.0);
+                    result = JsonValue.Create(((short)_value.Value) / 10.0);
                     _value = null;
                     return result;
                 case "US10":
-                    result = new JValue(_value.Value / 10.0);
+                    result = JsonValue.Create(_value.Value / 10.0);
                     _value = null;
                     return result;
                 case "SS100":
-                    result = new JValue(((short)_value.Value) / 100.0);
+                    result = JsonValue.Create(((short)_value.Value) / 100.0);
                     _value = null;
                     return result;
                 case "SSPR":
-                    result = new JValue(((short) _value.Value) * (1.0 / 255));
+                    result = JsonValue.Create(((short) _value.Value) * (1.0 / 255));
                     _value = null;
                     return result;
                 case "US4":
-                    result = new JValue(_value.Value / 4.0);
+                    result = JsonValue.Create(_value.Value / 4.0);
                     _value = null;
                     return result;
                 case "IntDiv60":
-                    result = new JValue(_value.Value / 60.0);
+                    result = JsonValue.Create(_value.Value / 60.0);
                     _value = null;
                     return result;
                 default:
@@ -60,34 +60,34 @@ namespace ism7mqtt.ISM7.Xml
             }
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             ushort data;
             switch (Type)
             {
                 case "US":
-                    data = UInt16.Parse(value.Value.ToString());
+                    data = value.GetValue<UInt16>();
                     break;
                 case "SS":
-                    data = (ushort) Int16.Parse(value.Value.ToString());
+                    data = (ushort) value.GetValue<short>();
                     break;
                 case "SS10":
-                    data = (ushort) (Double.Parse(value.Value.ToString()) * 10);
+                    data = (ushort) (value.GetValue<double>() * 10);
                     break;
                 case "US10":
-                    data = (ushort) (Double.Parse(value.Value.ToString()) * 10);
+                    data = (ushort) (value.GetValue<double>() * 10);
                     break;
                 case "SS100":
-                    data = (ushort) (Double.Parse(value.Value.ToString()) * 100);
+                    data = (ushort) (value.GetValue<double>() * 100);
                     break;
                 case "SSPR":
-                    data = (ushort) (Double.Parse(value.Value.ToString()) * (1.0/256));
+                    data = (ushort) (value.GetValue<double>() * (1.0/256));
                     break;
                 case "US4":
-                    data = (ushort) (Double.Parse(value.Value.ToString()) * 4);
+                    data = (ushort) (value.GetValue<double>() * 4);
                     break;
                 case "IntDiv60":
-                    data = (ushort) (Double.Parse(value.Value.ToString()) * 60);
+                    data = (ushort) (value.GetValue<double>() * 60);
                     break;
                 default:
                     throw new NotImplementedException($"type '{Type}' for CTID '{CTID}' is not yet implemented");

--- a/src/ism7mqtt/ISM7/Xml/NumericConverter32Template.cs
+++ b/src/ism7mqtt/ISM7/Xml/NumericConverter32Template.cs
@@ -59,7 +59,7 @@ namespace ism7mqtt.ISM7.Xml
             switch (Type)
             {
                 case "UINT32":
-                    var data = value.GetValue<int>();
+                    if (!UInt32.TryParse(value.ToString(), out var data)) yield break;
                     low = (ushort) (data & 0xffff);
                     high = (ushort) (data >> 16);
                     break;

--- a/src/ism7mqtt/ISM7/Xml/NumericConverter32Template.cs
+++ b/src/ism7mqtt/ISM7/Xml/NumericConverter32Template.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -34,16 +34,16 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _high.HasValue && _low.HasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             if (!HasValue)
                 throw new InvalidOperationException();
             var value = (_high.Value << 16) | _low.Value;
-                    JValue result;
+            JsonValue result;
             switch (Type)
             {
                 case "UINT32":
-                    result = new JValue((uint) value);
+                    result = JsonValue.Create((uint) value);
                     _high = null;
                     _low = null;
                     return result;
@@ -52,14 +52,14 @@ namespace ism7mqtt.ISM7.Xml
             }
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             ushort low;
             ushort high;
             switch (Type)
             {
                 case "UINT32":
-                    var data = UInt32.Parse(value.Value.ToString());
+                    var data = value.GetValue<int>();
                     low = (ushort) (data & 0xffff);
                     high = (ushort) (data >> 16);
                     break;

--- a/src/ism7mqtt/ISM7/Xml/ParameterDescriptor.cs
+++ b/src/ism7mqtt/ISM7/Xml/ParameterDescriptor.cs
@@ -43,10 +43,10 @@ namespace ism7mqtt.ISM7.Xml
             }
         }
 
-        public virtual IEnumerable<KeyValuePair<string,JsonNode>> GetValues(ConverterTemplateBase converter)
+        public virtual KeyValuePair<string,JsonNode> GetValues(ConverterTemplateBase converter)
         {
             var value = converter.GetValue();
-            yield return new KeyValuePair<string,JsonNode>(SafeName, value);
+            return new KeyValuePair<string,JsonNode>(SafeName, value);
         }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/ParameterDescriptor.cs
+++ b/src/ism7mqtt/ISM7/Xml/ParameterDescriptor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -43,10 +43,10 @@ namespace ism7mqtt.ISM7.Xml
             }
         }
 
-        public virtual IEnumerable<JProperty> GetValues(ConverterTemplateBase converter)
+        public virtual IEnumerable<KeyValuePair<string,JsonNode>> GetValues(ConverterTemplateBase converter)
         {
             var value = converter.GetValue();
-            yield return new JProperty(SafeName, value);
+            yield return new KeyValuePair<string,JsonNode>(SafeName, value);
         }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/SolarStatisticConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/SolarStatisticConverterTemplate.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -36,7 +36,7 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => _hasValue;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             var values = _values.Values.ToList();
             var wh = values[0];
@@ -52,10 +52,10 @@ namespace ism7mqtt.ISM7.Xml
                 value += mwh * 1_000_000UL;
             }
             _hasValue = false;
-            return new JValue(value);
+            return JsonValue.Create(value);
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/Timeprog03F1ConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/Timeprog03F1ConverterTemplate.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -29,12 +29,12 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => false;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/TimeprogConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/TimeprogConverterTemplate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -14,12 +14,12 @@ namespace ism7mqtt.ISM7.Xml
 
         public override bool HasValue => false;
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/ISM7/Xml/UnicodeTextConverter.cs
+++ b/src/ism7mqtt/ISM7/Xml/UnicodeTextConverter.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Nodes;
 using ism7mqtt.ISM7.Protocol;
-using Newtonsoft.Json.Linq;
 
 namespace ism7mqtt.ISM7.Xml
 {
@@ -35,7 +35,7 @@ namespace ism7mqtt.ISM7.Xml
             }
         }
 
-        public override JValue GetValue()
+        public override JsonValue GetValue()
         {
             if (_broken)
             {
@@ -47,10 +47,10 @@ namespace ism7mqtt.ISM7.Xml
                 sb.Append((char)letter);
             }
             _letters.Clear();
-            return new JValue(sb.ToString());
+            return JsonValue.Create(sb.ToString());
         }
 
-        public override IEnumerable<InfoWrite> GetWrite(JValue value)
+        public override IEnumerable<InfoWrite> GetWrite(JsonValue value)
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }

--- a/src/ism7mqtt/MqttMessage.cs
+++ b/src/ism7mqtt/MqttMessage.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Collections.Generic;
+using System.Text.Json.Nodes;
 
 namespace ism7mqtt
 {
@@ -7,16 +8,16 @@ namespace ism7mqtt
         public MqttMessage(string path)
         {
             Path = path;
-            Content = new JObject();
+            Content = new JsonObject();
         }
 
         public string Path { get; }
 
-        public JObject Content { get; }
+        public JsonObject Content { get; }
 
         public bool HasContent { get; private set; }
 
-        public void AddProperty(JProperty property)
+        public void AddProperty(KeyValuePair<string,JsonNode> property)
         {
             HasContent = true;
             Content.Add(property);

--- a/src/ism7mqtt/MqttMessage.cs
+++ b/src/ism7mqtt/MqttMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace ism7mqtt
@@ -20,7 +21,17 @@ namespace ism7mqtt
         public void AddProperty(KeyValuePair<string,JsonNode> property)
         {
             HasContent = true;
-            Content.Add(property);
+            if (Content.TryGetPropertyValue(property.Key, out var value))
+            {
+                foreach (var prop in property.Value.AsObject())
+                {
+                    value.AsObject().Add(prop.Key, prop.Value.Deserialize<JsonNode>());
+                }
+            }
+            else
+            {
+                Content.Add(property);
+            }
         }
     }
 }

--- a/src/ism7mqtt/Program.cs
+++ b/src/ism7mqtt/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Net;
@@ -106,7 +107,7 @@ namespace ism7mqtt
                         });
                         await mqttClient.ConnectAsync(mqttOptions, cts.Token);
                         await mqttClient.SubscribeAsync($"Wolf/{ip}/+/set");
-                        await mqttClient.SubscribeAsync($"Wolf/{ip}/+/set/+");
+                        await mqttClient.SubscribeAsync($"Wolf/{ip}/+/set/#");
                         var client = new Ism7Client((m, c) => OnMessage(mqttClient, m, enableDebug, c), parameter, IPAddress.Parse(ip))
                         {
                             Interval = interval,
@@ -166,16 +167,23 @@ namespace ism7mqtt
             if (message.Topic.EndsWith("/set"))
             {
                 //json
-                data = JsonNode.Parse(message.ConvertPayloadToString()).AsObject();
+                data = JsonSerializer.Deserialize<JsonObject>(message.ConvertPayloadToString());
                 topic = message.Topic.Substring(0, message.Topic.Length - 4);
             }
             else
             {
                 //single value
-                var index = message.Topic.LastIndexOf('/');
-                var property = message.Topic.Substring(index + 1);
-                topic = message.Topic.Substring(0, index - 4);
-                data = new JsonObject{{property, JsonValue.Create(message.ConvertPayloadToString())}};
+                var index = message.Topic.LastIndexOf("/set/");
+                var property = message.Topic.Substring(index + 5);
+                topic = message.Topic.Substring(0, index);
+                var propertyParts = property.Split('/').AsSpan();
+                data = new JsonObject{{propertyParts[^1], JsonValue.Create(message.ConvertPayloadToString())}};
+                propertyParts = propertyParts[..^1];
+                while (!propertyParts.IsEmpty)
+                {
+                    data = new JsonObject{{propertyParts[^1], data}};
+                    propertyParts = propertyParts[..^1];
+                }
             }
             return client.OnCommandAsync(topic, data, cancellationToken);
         }
@@ -209,10 +217,8 @@ namespace ism7mqtt
             }
             if (_useSeparateTopics)
             {
-                foreach (var property in message.Content)
+                foreach (var (name, data) in Flatten(message.Content))
                 {
-                    var name = EscapeMqttTopic(property.Key);
-                    var data = JsonSerializer.Serialize(property.Value);
                     var topic = $"{message.Path}/{name}";
                     var builder = new MqttApplicationMessageBuilder().WithTopic(topic)
                         .WithPayload(data);
@@ -224,6 +230,25 @@ namespace ism7mqtt
                         Console.WriteLine($"publishing mqtt with topic '{topic}' '{data}'");
                     }
                     await client.PublishAsync(payload, cancellationToken);
+                }
+            }
+        }
+
+        private static IEnumerable<(string, string)> Flatten(JsonObject data)
+        {
+            foreach (var property in data)
+            {
+                var topic = EscapeMqttTopic(property.Key);
+                if (property.Value is JsonObject nested)
+                {
+                    foreach (var (path, value) in Flatten(nested))
+                    {
+                        yield return ($"{topic}/{path}", value);
+                    }
+                }
+                else
+                {
+                    yield return (topic, property.Value?.ToString());
                 }
             }
         }

--- a/src/ism7mqtt/ism7mqtt.csproj
+++ b/src/ism7mqtt/ism7mqtt.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="MQTTnet" Version="3.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Breaking Change

Previously there were some inconsistencies in escaping and json payload handling - now there is a consistent structure, you can always publish to the corresponding set endpoint with the same structure and also get proper error messages logged when a message is discarded.

Also switched from `Newtonsoft.Json` to `System.Text.Json`.

### ISM to MQTT

- previously published duplicates with the suffix `_<PTID>` - those are now nested objects
- for `ListParameter` it published an additional json property with the suffix `_Text` - now there is an object with the properties `name` & `text`

### MQTT to ISM

- previously you had to publish to the unescaped topic - now the escaping is consistent in both directions
- for json payload the structure is identical to the published values

fixes #22 