### PR TITLE
fix output of BinaryReadOnlyConverterTemplate and corresponding ha discovery topics

### DIFF
--- a/src/ism7mqtt/HomeAssistant/HaDiscovery.cs
+++ b/src/ism7mqtt/HomeAssistant/HaDiscovery.cs
@@ -129,10 +129,6 @@ namespace ism7mqtt.HomeAssistant
         {
             if (descriptor is ListParameterDescriptor list)
             {
-                if (!list.IsWritable && list.IsBoolean)
-                {
-                    return String.Empty;
-                }
                 return "/text";
             }
             else
@@ -193,42 +189,34 @@ namespace ism7mqtt.HomeAssistant
                     }
                     break;
                 case ListParameterDescriptor list:
-                    if (list.IsWritable)
+                    if (list.IsBoolean)
                     {
-                        if (list.IsBoolean)
+                        if (list.Options.Any(x => x.Value == "Ein"))
                         {
-                            if (list.Options.Any(x => x.Value == "Ein"))
-                            {
-                                yield return("payload_on", "Ein");
-                            }
-                            if (list.Options.Any(x => x.Value == "Aktiviert"))
-                            {
-                                yield return("payload_on", "Aktiviert");
-                            }
-                            if (list.Options.Any(x => x.Value == "Aus"))
-                            {
-                                yield return("payload_off", "Aus");
-                            }
-                            if (list.Options.Any(x => x.Value == "Deaktiviert"))
-                            {
-                                yield return("payload_off", "Deaktiviert");
-                            }
+                            yield return ("payload_on", "Ein");
                         }
-                        else
+                        if (list.Options.Any(x => x.Value == "Aktiviert"))
                         {
-                            var options = new JsonArray();
-                            foreach (var value in list.Options)
-                            {
-                                options.Add(value.Value);
-                            }
-                            yield return("options", options);
-
+                            yield return ("payload_on", "Aktiviert");
+                        }
+                        if (list.Options.Any(x => x.Value == "Aus"))
+                        {
+                            yield return ("payload_off", "Aus");
+                        }
+                        if (list.Options.Any(x => x.Value == "Deaktiviert"))
+                        {
+                            yield return ("payload_off", "Deaktiviert");
                         }
                     }
-                    else if (list.IsBoolean)
+                    else
                     {
-                        yield return("payload_on", "true");
-                        yield return("payload_off", "false");
+                        var options = new JsonArray();
+                        foreach (var value in list.Options)
+                        {
+                            options.Add(value.Value);
+                        }
+                        yield return ("options", options);
+
                     }
                     break;
                 default:

--- a/src/ism7mqtt/ISM7/Ism7Config.cs
+++ b/src/ism7mqtt/ISM7/Ism7Config.cs
@@ -475,16 +475,6 @@ namespace ism7mqtt
                     if (listDescriptor.Options.Any())
                     {
                         var key = value.Content;
-                        // some list types have a binary/bool converter, even if it doesn't make much sense.. try to detect those cases
-                        if (!listDescriptor.IsBoolean && _converter is BinaryReadOnlyConverterTemplate)
-                        {
-                            key = key switch
-                            {
-                                "false" => "0",
-                                "true" => "1",
-                                _ => key
-                            };
-                        }
                         var text = listDescriptor.Options.Where(x => x.Key == key).Select(x => x.Value).FirstOrDefault();
                         if (!String.IsNullOrEmpty(text))
                         {

--- a/src/ism7mqtt/ISM7/Xml/BinaryReadOnlyConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/BinaryReadOnlyConverterTemplate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ism7mqtt.ISM7.Protocol;
@@ -22,13 +23,14 @@ namespace ism7mqtt.ISM7.Xml
             _bit = (value >> Bitnumber) & 0x1;
         }
 
+        [MemberNotNullWhen(true, nameof(_bit))]
         public override bool HasValue => _bit.HasValue;
 
         public override JsonValue GetValue()
         {
             if (!HasValue)
                 throw new InvalidOperationException();
-            var result = JsonValue.Create(_bit.Value == OnValue);
+            var result = JsonValue.Create(_bit.Value == OnValue ? 1 : 0);
             _bit = null;
             return result;
         }


### PR DESCRIPTION
the parameter & converter templates clearly show that the output of the BinaryReadOnlyConverterTemplate needs to be numeric (0,1) to be used as input for ListParameterDescriptor KeyValueList mapping or as input for NumericParameterDescriptor.

fixes #59 