### PR TITLE
ignore system-config-response and always add all devices

### DIFF
--- a/src/ism7config/Config.cs
+++ b/src/ism7config/Config.cs
@@ -14,6 +14,8 @@ class Device
 
     public string ReadBusAddress { get; set; }
 
+    public string WriteBusAddress { get; set; }
+
     public int DeviceTemplateId { get; set; }
 
     [JsonIgnore]

--- a/src/ism7config/Program.cs
+++ b/src/ism7config/Program.cs
@@ -142,6 +142,7 @@ internal class Program
                     {
                         Id = device.Id,
                         ReadBusAddress = device.ReadBusAddress,
+                        WriteBusAddress = device.WriteBusAddress,
                         DeviceTemplateId = device.DeviceTemplateId,
                         Parameters = parameterStore.Parameters
                             .Where(x=>x.Value.DeviceId == device.Id)

--- a/src/ism7config/Program.cs
+++ b/src/ism7config/Program.cs
@@ -135,7 +135,7 @@ internal class Program
                 {
                     Devices = new List<Device>()
                 };
-                foreach (var device in gc.Devices)
+                foreach (var device in gc.Devices.OrderBy(x => x.ReadBusAddress))
                 {
                     if (device.DeviceTemplateId == 0) continue; //skip devices with invalid template id as seen in #64
                     config.Devices.Add(new Device
@@ -145,8 +145,10 @@ internal class Program
                         WriteBusAddress = device.WriteBusAddress,
                         DeviceTemplateId = device.DeviceTemplateId,
                         Parameters = parameterStore.Parameters
-                            .Where(x=>x.Value.DeviceId == device.Id)
-                            .Select(x=>new Parameter{ParameterId = x.Value.ParameterId / 100_000}).ToList()
+                            .Where(x => x.Value.DeviceId == device.Id)
+                            .Select(x => new Parameter { ParameterId = x.Value.ParameterId / 100_000 })
+                            .OrderBy(x => x.ParameterId)
+                            .ToList()
                     });
                 }
                 await File.WriteAllTextAsync(file, JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }));

--- a/src/ism7mqtt/ISM7/Config/ParameterConfig.cs
+++ b/src/ism7mqtt/ISM7/Config/ParameterConfig.cs
@@ -12,6 +12,8 @@ namespace ism7mqtt.ISM7.Config
     {
         public string ReadBusAddress { get; set; }
 
+        public string WriteBusAddress { get; set; }
+
         public int DeviceTemplateId { get; set; }
 
         public List<int> Parameter { get; set; }

--- a/src/ism7mqtt/ISM7/Ism7Config.cs
+++ b/src/ism7mqtt/ISM7/Ism7Config.cs
@@ -167,7 +167,7 @@ namespace ism7mqtt
                 Name = name;
                 IP = ip;
 
-                WriteAddress = writeBusAddress;
+                WriteAddress = writeBusAddress ?? $"0x{(Converter.FromHex(readBusAddress) - 5):X2}";
                 MqttTopic = $"Wolf/{ip}/{name}_{readBusAddress}";
 
                 _parameter = new List<RunningParameter>();

--- a/src/ism7mqtt/ISM7/Ism7Config.cs
+++ b/src/ism7mqtt/ISM7/Ism7Config.cs
@@ -313,10 +313,10 @@ namespace ism7mqtt
             private readonly ParameterDescriptor _descriptor;
             private readonly ConverterTemplateBase _converter;
 
-            public RunningParameter( ParameterDescriptor descriptor, ConverterTemplateBase converter)
+            public RunningParameter(ParameterDescriptor descriptor, ConverterTemplateBase converter)
             {
                 _descriptor = descriptor;
-                _converter = converter;
+                _converter = converter.Clone();
             }
 
             public string Name => _descriptor.Name;

--- a/src/ism7mqtt/ISM7/Xml/BM2DateConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/BM2DateConverterTemplate.cs
@@ -39,5 +39,10 @@ namespace ism7mqtt.ISM7.Xml
             var high = (byte)(bytes >> 8);
             yield return new InfoWrite{InfoNumber = TelegramNr, DBLow = $"0x{low:X2}", DBHigh = $"0x{high:X2}"};
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new BM2DateConverterTemplate());
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/BM2TimeConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/BM2TimeConverterTemplate.cs
@@ -32,5 +32,10 @@ namespace ism7mqtt.ISM7.Xml
             var low = time.Minutes;
             yield return new InfoWrite{InfoNumber = TelegramNr, DBLow = $"0x{low:X2}", DBHigh = $"0x{high:X2}"};
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new BM2TimeConverterTemplate());
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/BinaryReadOnlyConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/BinaryReadOnlyConverterTemplate.cs
@@ -39,5 +39,14 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new BinaryReadOnlyConverterTemplate
+            {
+                OnValue = OnValue,
+                Bitnumber = Bitnumber,
+            });
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/Bit0to3ConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/Bit0to3ConverterTemplate.cs
@@ -31,5 +31,10 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new Bit0to3ConverterTemplate());
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/Bit4to7ConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/Bit4to7ConverterTemplate.cs
@@ -31,5 +31,10 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new Bit4to7ConverterTemplate());
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/ConverterTemplateBase.cs
+++ b/src/ism7mqtt/ISM7/Xml/ConverterTemplateBase.cs
@@ -30,5 +30,16 @@ namespace ism7mqtt.ISM7.Xml
         public abstract JsonValue GetValue();
 
         public abstract IEnumerable<InfoWrite> GetWrite(string value);
+
+        public abstract ConverterTemplateBase Clone();
+
+        protected ConverterTemplateBase Clone(ConverterTemplateBase clone)
+        {
+            clone.CTID = CTID;
+            clone.Type = Type;
+            clone.ServiceReadNumber = ServiceReadNumber;
+            clone.ServiceWriteNumber = ServiceWriteNumber;
+            return clone;
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/ConverterTemplateBase.cs
+++ b/src/ism7mqtt/ISM7/Xml/ConverterTemplateBase.cs
@@ -33,7 +33,7 @@ namespace ism7mqtt.ISM7.Xml
 
         public abstract ConverterTemplateBase Clone();
 
-        protected ConverterTemplateBase Clone(ConverterTemplateBase clone)
+        protected virtual ConverterTemplateBase Clone(ConverterTemplateBase clone)
         {
             clone.CTID = CTID;
             clone.Type = Type;

--- a/src/ism7mqtt/ISM7/Xml/DateTimeConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/DateTimeConverterTemplate.cs
@@ -23,5 +23,10 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new DateTimeConverterTemplate());
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/MixerStateConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/MixerStateConverterTemplate.cs
@@ -67,5 +67,14 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new MixerStateConverterTemplate
+            {
+                TelegramNrOpen = TelegramNrOpen,
+                TelegramNrClose = TelegramNrClose,
+            });
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/MultiTelegramConverterTemplateBase.cs
+++ b/src/ism7mqtt/ISM7/Xml/MultiTelegramConverterTemplateBase.cs
@@ -22,5 +22,15 @@ namespace ism7mqtt.ISM7.Xml
         {
             return TelegramNumbers.Any(x => x == telegram);
         }
+
+        protected override ConverterTemplateBase Clone(ConverterTemplateBase clone)
+        {
+            base.Clone(clone);
+            if (clone is MultiTelegramConverterTemplateBase multi)
+            {
+                multi.TelegramNumbers = TelegramNumbers;
+            }
+            return clone;
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/NullConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/NullConverterTemplate.cs
@@ -37,5 +37,14 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new NullConverterTemplate
+            {
+                XMLName = XMLName,
+                IntervalSec = IntervalSec,
+            });
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/NumericConverter16Template.cs
+++ b/src/ism7mqtt/ISM7/Xml/NumericConverter16Template.cs
@@ -96,5 +96,10 @@ namespace ism7mqtt.ISM7.Xml
             }
             yield return new InfoWrite{InfoNumber = TelegramNr, DBLow = $"0x{(data & 0xff):X2}", DBHigh = $"0x{(data >> 8):X2}"};
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new NumericConverter16Template());
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/NumericConverter32Template.cs
+++ b/src/ism7mqtt/ISM7/Xml/NumericConverter32Template.cs
@@ -84,5 +84,14 @@ namespace ism7mqtt.ISM7.Xml
             yield return new InfoWrite{InfoNumber = TelegramNrLow, DBLow = $"0x{(low & 0xff):X2}", DBHigh = $"0x{(low >> 8):X2}"};
             yield return new InfoWrite{InfoNumber = TelegramNrHigh, DBLow = $"0x{(high & 0xff):X2}", DBHigh = $"0x{(high >> 8):X2}"};
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new NumericConverter32Template
+            {
+                TelegramNrHigh = TelegramNrHigh,
+                TelegramNrLow = TelegramNrLow,
+            });
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/SingleTelegramConverterTemplateBase.cs
+++ b/src/ism7mqtt/ISM7/Xml/SingleTelegramConverterTemplateBase.cs
@@ -30,5 +30,14 @@ namespace ism7mqtt.ISM7.Xml
         }
 
         protected abstract void AddTelegram(byte low, byte high);
+
+        protected override ConverterTemplateBase Clone(ConverterTemplateBase clone)
+        {
+            if (clone is SingleTelegramConverterTemplateBase single)
+            {
+                single.TelegramNr = TelegramNr;
+            }
+            return base.Clone(clone);
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/SolarStatisticConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/SolarStatisticConverterTemplate.cs
@@ -18,14 +18,7 @@ namespace ism7mqtt.ISM7.Xml
             if (Type == KwMwType || Type == KwType)
             {
                 var value = (uint)(high << 8) | low;
-                if (!_values.ContainsKey(telegram))
-                {
-                    _values.Add(telegram, value);
-                }
-                else
-                {
-                    _values[telegram] = value;
-                }
+                _values[telegram] = value;
                 _hasValue = true;
             }
             else
@@ -60,6 +53,11 @@ namespace ism7mqtt.ISM7.Xml
         public override IEnumerable<InfoWrite> GetWrite(string value)
         {
             throw new NotImplementedException($"CTID '{CTID}' ({nameof(SolarStatisticConverterTemplate)}) is not yet implemented");
+        }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new SolarStatisticConverterTemplate());
         }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/Timeprog03F1ConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/Timeprog03F1ConverterTemplate.cs
@@ -43,5 +43,16 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new Timeprog03F1ConverterTemplate
+            {
+                DayOfWeek = DayOfWeek,
+                HeatprogNumber = HeatprogNumber,
+                ProgramType = ProgramType,
+                HzkInstance = HzkInstance,
+            });
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/TimeprogConverterTemplate.cs
+++ b/src/ism7mqtt/ISM7/Xml/TimeprogConverterTemplate.cs
@@ -23,5 +23,10 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new TimeprogConverterTemplate());
+        }
     }
 }

--- a/src/ism7mqtt/ISM7/Xml/UnicodeTextConverter.cs
+++ b/src/ism7mqtt/ISM7/Xml/UnicodeTextConverter.cs
@@ -54,5 +54,10 @@ namespace ism7mqtt.ISM7.Xml
         {
             throw new NotImplementedException($"CTID '{CTID}' is not yet implemented");
         }
+
+        public override ConverterTemplateBase Clone()
+        {
+            return Clone(new UnicodeTextConverter());
+        }
     }
 }


### PR DESCRIPTION
There are additional devices on the bus, which are not reported by the system-config-response. Since the parameter.json was generated by the wolf binaries we can assume that the devices are correct. Some devices also use the same address for reading and writing instead of the default offset `-5` - so the parameter.json now also stores the WriteBusAddress from the config run.

fixes #72 