### PR TITLE
WIP: Limit number of datapoints client subscribes to

### DIFF
--- a/src/ism7mqtt/ISM7/Ism7Config.cs
+++ b/src/ism7mqtt/ISM7/Ism7Config.cs
@@ -91,7 +91,7 @@ namespace ism7mqtt
         public IEnumerable<InfoRead> GetInfoReadForDevice(string ba)
         {
             var devices = _devices[Converter.FromHex(ba)];
-            return devices.SelectMany(x => x.InfoReads);
+            return devices.SelectMany(x => x.InfoReads).DistinctBy(ir => ir.InfoNumber);
         }
 
         public bool ProcessData(IEnumerable<InfonumberReadResp> data)


### PR DESCRIPTION
This allows capping number of datapoints client subscribes to test setting parameters (https://github.com/zivillian/ism7mqtt/issues/57#issuecomment-1874103810).