### PR TITLE
Allow empty discoveryId

### DIFF
--- a/src/ism7mqtt/Program.cs
+++ b/src/ism7mqtt/Program.cs
@@ -39,6 +39,7 @@ namespace ism7mqtt
             _retain = GetEnvBool("ISM7_RETAIN");
             int interval = GetEnvInt32("ISM7_INTERVAL", 60);
             string discoveryId = GetEnvString("ISM7_HOMEASSISTANT_ID");
+            bool emptyDiscoveryId = GetEnvBool("ISM7_EMPTY_HOMEASSISTANT_ID");
             var options = new OptionSet
             {
                 {"m|mqttServer=", "MQTT Server", x => mqttHost = x},
@@ -53,6 +54,7 @@ namespace ism7mqtt
                 {"retain", "retain mqtt messages", x=> _retain = x != null},
                 {"interval=", "push interval in seconds (defaults to 60)", (int x) => interval = x},
                 {"hass-id=", "HomeAssistant auto-discovery device id/entity prefix (implies --separate and --retain)", x => discoveryId = x},
+                {"empty-hass-id", "Use HomeAssistant without an additional device id/entity prefix", x => emptyDiscoveryId = x!= null},
                 {"d|debug", "dump raw xml messages", x => enableDebug = x != null},
                 {"h|help", "show help", x => showHelp = x != null},
             };
@@ -81,7 +83,7 @@ namespace ism7mqtt
                 return;
             }
 
-            if (!String.IsNullOrEmpty(discoveryId))
+            if (!String.IsNullOrEmpty(discoveryId) || emptyDiscoveryId)
             {
                 _retain = true;
                 _useSeparateTopics = true;
@@ -129,7 +131,7 @@ namespace ism7mqtt
                         };
                         mqttClient.UseApplicationMessageReceivedHandler(x => OnMessage(client, x, enableDebug, cts.Token));
 
-                        if (!String.IsNullOrEmpty(discoveryId))
+                        if (!String.IsNullOrEmpty(discoveryId) || emptyDeicoveryId)
                         {
                             await mqttClient.SubscribeAsync("homeassistant/status");
                             client.OnInitializationFinishedAsync = (config, c) =>


### PR DESCRIPTION
I was wondering for quite some time, why nothing really worked anymore. 
Looks like the fix for #101 (i.e. ignoring empty discoveryID) killed it for me.
Would it be possible to implement something like what I dabbled together in this PR?