### PR TITLE
Use XmlSerializerNamespaces to remove the namespace attributes

### DIFF
--- a/src/ism7mqtt/ISM7/Protocol/XmlPayload.cs
+++ b/src/ism7mqtt/ISM7/Protocol/XmlPayload.cs
@@ -10,14 +10,18 @@ namespace ism7mqtt.ISM7.Protocol
     public abstract class XmlPayload : IPayload
     {
         private static readonly ConcurrentDictionary<Type, XmlSerializer> _serializers = new ConcurrentDictionary<Type, XmlSerializer>();
+        private static readonly XmlSerializerNamespaces _serializerNamespaces = new XmlSerializerNamespaces();
 
+        static XmlPayload() {
+            _serializerNamespaces.Add("", "");
+        }
         public byte[] Serialize()
         {
             using var sw = new Utf8StringWriter();
             var xmlWriter = XmlWriter.Create(sw, new XmlWriterSettings {Indent = false});
 
             var serializer = _serializers.GetOrAdd(GetType(), x => new XmlSerializer(x));
-            serializer.Serialize(xmlWriter, this);
+            serializer.Serialize(xmlWriter, this, _serializerNamespaces);
             sw.Flush();
             var xml = sw.ToString();
             return Encoding.UTF8.GetBytes(xml);

--- a/src/ism7mqtt/ISM7/Protocol/XmlPayload.cs
+++ b/src/ism7mqtt/ISM7/Protocol/XmlPayload.cs
@@ -12,9 +12,11 @@ namespace ism7mqtt.ISM7.Protocol
         private static readonly ConcurrentDictionary<Type, XmlSerializer> _serializers = new ConcurrentDictionary<Type, XmlSerializer>();
         private static readonly XmlSerializerNamespaces _serializerNamespaces = new XmlSerializerNamespaces();
 
-        static XmlPayload() {
+        static XmlPayload()
+        {
             _serializerNamespaces.Add("", "");
         }
+
         public byte[] Serialize()
         {
             using var sw = new Utf8StringWriter();


### PR DESCRIPTION
ism7mqtt generates XML with namespace attributes, which the XML of the Wolf Smartset does not contain.

This PR removes the 
`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"` and 
`xmlns:xsd="http://www.w3.org/2001/XMLSchema"` attributes by using a XmlSerializerNamespaces object.

Instead of 
`<direct-logon-request xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><password>XXXXXXXX </password></direct-logon-request>`
the XML generated will be:
`<direct-logon-request><password>XXXXXXXXX</password></direct-logon-request>`

Maybe it helps with #112 , but even if not there is no negative impact.
