### PR TITLE
Add more sensor units to the home assistant Long term statistics

### DIFF
--- a/src/ism7mqtt/HomeAssistant/HaDiscovery.cs
+++ b/src/ism7mqtt/HomeAssistant/HaDiscovery.cs
@@ -239,6 +239,38 @@ namespace ism7mqtt.HomeAssistant
                         {
                             yield return ("state_class", "measurement");
                         }
+                        else if (numeric.UnitName == "kWh")
+                        {
+                            yield return ("state_class", "total_increasing");
+                            yield return ("device_class", "energy");
+                        }
+                        else if (numeric.UnitName == "W")
+                        {
+                            yield return ("state_class", "measurement");
+                            yield return ("device_class", "power");
+                        }
+                        else if (numeric.UnitName == "kW")
+                        {
+                            yield return ("state_class", "measurement");
+                            yield return ("device_class", "power");
+                        }
+                        else if (numeric.UnitName == "Hz")
+                        {
+                            yield return ("state_class", "measurement");
+                            yield return ("device_class", "frequency");
+                        }
+                        else if (numeric.UnitName == "l/min")
+                        {
+                            yield return ("state_class", "measurement");
+                        }
+                        else if (numeric.UnitName == "L/min")
+                        {
+                            yield return ("state_class", "measurement");
+                        }
+                        else if (numeric.UnitName == "U/min")
+                        {
+                            yield return ("state_class", "measurement");
+                        }
                     }
                     break;
                 case ListParameterDescriptor list:


### PR DESCRIPTION
Historical data in home assistant is purged after 10 days unless a sensor has defined the attribute `state_class`. At present only temperature and percentages are treated by ism7mqtt to be valuable for the home assistant long term statistics.

I think nearly all values are important to have them long term to be able to compare certain situations. So I added a few more units.

THE CHANGE IS NOT TESTED YET as due to my other long running test I do not want to stop at present (#115 ). So this just a draft PR.