### PR TITLE
fix auto discover creates unnamed_device entry

### DIFF
--- a/src/ism7mqtt/HomeAssistant/HaDiscovery.cs
+++ b/src/ism7mqtt/HomeAssistant/HaDiscovery.cs
@@ -111,7 +111,7 @@ namespace ism7mqtt.HomeAssistant
                 }
 
                 message.Add("name", _localizer[descriptor.Name]);
-                message.Add("default_entity_id", uniqueId);
+                message.Add("default_entity_id", $"{(type ?? "unknown")}.{uniqueId}");
 
                 foreach (var (key, value) in GetDiscoveryProperties(descriptor))
                 {


### PR DESCRIPTION
Fixes the creation of entities with `unnamed_device_` prefix as entity ID. See issue https://github.com/zivillian/ism7mqtt/issues/206.