### PR TITLE
Restore shutdown on connection error

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,9 @@ name: Docker
 
 on:
   push:
-    branches: [ krusta4711_restore_shutdown_on_connection_error ]
+    branches: [ master ]
     tags:
-      - krusta4711_restore_shutdown_on_connection_error
+      - '*'
 
 jobs:
   docker:
@@ -25,11 +25,16 @@ jobs:
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: zivillian/ism7mqtt
     - name: Build
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
-        tags: krusta/ism7mqtt_fork:test_exit_again_on_error
-        labels: krusta/ism7mqtt_fork:test_exit_again_on_error
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,9 @@ name: Docker
 
 on:
   push:
-    branches: [ master ]
+    branches: [ krusta4711_restore_shutdown_on_connection_error ]
     tags:
-      - '*'
+      - krusta4711_restore_shutdown_on_connection_error
 
 jobs:
   docker:
@@ -25,16 +25,11 @@ jobs:
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: zivillian/ism7mqtt
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: krusta/ism7mqtt_fork:test_exit_again_on_error
+        labels: krusta/ism7mqtt_fork:test_exit_again_on_error

--- a/src/ism7mqtt/ISM7/Ism7Client.cs
+++ b/src/ism7mqtt/ISM7/Ism7Client.cs
@@ -180,9 +180,7 @@ namespace ism7mqtt
                             var done = await Task.WhenAny(tasks);
                             tasks.Remove(done);                          
                             if (done.IsFaulted)
-                            {
-                                Console.WriteLine(done.Exception?.InnerException ?? done.Exception);
-                            }
+                                await done;
                             if (done == readTask) break;
                         }
 


### PR DESCRIPTION
With version v0.0.19 on connection error ism7mqtt exited. That leads to HA Addon user do not get a restart anymore. No updates arrive any more. 

Solution with the new limit in-flight request to have back the same behavior:
"await done" on a faulted task re-throws its inner exception. That exception escapes the inner while (true) loop and the outer while (_!cancellationToken.IsCancellationRequested_) loop, and is caught by the existing outer catch (Exception ex) block at line 226, which already logs it and calls source.CompleteAsync(ex). _ReadPipeAsync_ then exits cleanly.