### PR TITLE
Interrupt startup on timeout

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,8 @@ name: Docker
 
 on:
   push:
-    branches: [ master ]
-    tags:
-      - '*'
+    branches: [ krusta4711_interrupt_startup_on_timeout ]
+
 
 jobs:
   docker:
@@ -19,6 +18,8 @@ jobs:
       run: |
         dotnet tool install --global minver-cli --version 6.0.0
         echo "version=$(minver --tag-prefix v)" >> $GITHUB_OUTPUT
+    - name: Log version passed to Docker
+      run: echo "Passing VERSION=${{ steps.version.outputs.version }} to Docker build"
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -27,17 +28,12 @@ jobs:
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: zivillian/ism7mqtt
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: krusta/ism7mqtt_fork:interrupt_startup_on_timeout
+        labels: krusta/ism7mqtt_fork:interrupt_startup_on_timeout
         build-args: VERSION=${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,9 @@ name: Docker
 
 on:
   push:
-    branches: [ krusta4711_interrupt_startup_on_timeout ]
-
+    branches: [ master ]
+    tags:
+      - '*'
 
 jobs:
   docker:
@@ -18,8 +19,6 @@ jobs:
       run: |
         dotnet tool install --global minver-cli --version 6.0.0
         echo "version=$(minver --tag-prefix v)" >> $GITHUB_OUTPUT
-    - name: Log version passed to Docker
-      run: echo "Passing VERSION=${{ steps.version.outputs.version }} to Docker build"
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -28,12 +27,17 @@ jobs:
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: zivillian/ism7mqtt
     - name: Build
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
-        tags: krusta/ism7mqtt_fork:interrupt_startup_on_timeout_env
-        labels: krusta/ism7mqtt_fork:interrupt_startup_on_timeout_env
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         build-args: VERSION=${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,6 @@ jobs:
       with:
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
-        tags: krusta/ism7mqtt_fork:interrupt_startup_on_timeout
-        labels: krusta/ism7mqtt_fork:interrupt_startup_on_timeout
+        tags: krusta/ism7mqtt_fork:interrupt_startup_on_timeout_env
+        labels: krusta/ism7mqtt_fork:interrupt_startup_on_timeout_env
         build-args: VERSION=${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Possible environmental variables:
 * ISM7_PASSWORD
 * ISM7_DISABLEJSON
 * ISM7_SEPARATE
+* ISM7_STARTUP_TIMEOUT
+
+`ISM7_STARTUP_TIMEOUT` (in seconds, defaults to `90`, also available as `--startup-timeout`)
+only applies to the initial startup phase, where ism7mqtt requests all configured values from
+the ism7 one pull request at a time. It is **not** a timeout for the whole startup phase - it
+resets for every single pull request. If the ism7 does not answer one particular request within
+this time, ism7mqtt assumes the connection is stuck, logs the problem and exits so it can be
+restarted (e.g. by Docker's restart policy). Increase this value if your setup regularly needs
+more time to answer a single request; decrease it if you want ism7mqtt to fail faster on a
+stuck connection.
 
 ### HomeAssistant
 

--- a/src/ism7mqtt/ISM7/Ism7Client.cs
+++ b/src/ism7mqtt/ISM7/Ism7Client.cs
@@ -31,6 +31,10 @@ namespace ism7mqtt
 
         public int Interval { get; set; }
 
+        public int StartupTimeout { get; set; } = 90;
+
+        private TimeSpan StartupTimeoutSpan => TimeSpan.FromSeconds(StartupTimeout);
+
         public bool EnableDebug { get; set; }
 
         public Func<Ism7Config, CancellationToken, Task> OnInitializationFinishedAsync { get; set; }
@@ -276,10 +280,6 @@ namespace ism7mqtt
             }
         }
 
-        // We observed pull bundel request were not answered by the ISM7 which caused the startup to hang.
-        // With a timeout for each pull request we make sure the startup is interrupted and the user can see the problem in the logs.
-        private static readonly TimeSpan InitialValueTimeout = TimeSpan.FromSeconds(90);
-
         private async Task LoadInitialValuesAsync(CancellationToken cancellationToken)
         {
             var semaphore = new SemaphoreSlim(1, 1);
@@ -312,7 +312,7 @@ namespace ism7mqtt
                         infoRead.Seq = NextSequenceId();
                     }
 
-                    await WaitForBundleResponseAsync(semaphore, cancellationToken);
+                    await WaitForBundleResponseAsync(semaphore, StartupTimeoutSpan, cancellationToken);
                     await SendAsync(new TelegramBundleReq
                     {
                         AbortOnError = false,
@@ -325,7 +325,7 @@ namespace ism7mqtt
             }
 
             // Wait for the last pull response to be fully processed before subscribing.
-            await WaitForBundleResponseAsync(semaphore, cancellationToken);
+            await WaitForBundleResponseAsync(semaphore, StartupTimeoutSpan, cancellationToken);
 
             // Phase 2: send push subscribes after all pulls are complete
             foreach (var (busAddress, bundleId) in pendingSubscriptions)
@@ -339,10 +339,12 @@ namespace ism7mqtt
             }
         }
 
-        private static async Task WaitForBundleResponseAsync(SemaphoreSlim semaphore, CancellationToken cancellationToken)
+        // We observed pull bundel request were not answered by the ISM7 which caused the startup to hang.
+        // With a timeout for each pull request we make sure the startup is interrupted and the user can see the problem in the logs.
+        private static async Task WaitForBundleResponseAsync(SemaphoreSlim semaphore, TimeSpan timeout, CancellationToken cancellationToken)
         {
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCts.CancelAfter(InitialValueTimeout);
+            timeoutCts.CancelAfter(timeout);
             try
             {
                 await semaphore.WaitAsync(timeoutCts.Token);

--- a/src/ism7mqtt/ISM7/Ism7Client.cs
+++ b/src/ism7mqtt/ISM7/Ism7Client.cs
@@ -276,6 +276,10 @@ namespace ism7mqtt
             }
         }
 
+        // We observed pull bundel request were not answered by the ISM7 which caused the startup to hang.
+        // With a timeout for each pull request we make sure the startup is interrupted and the user can see the problem in the logs.
+        private static readonly TimeSpan InitialValueTimeout = TimeSpan.FromSeconds(90);
+
         private async Task LoadInitialValuesAsync(CancellationToken cancellationToken)
         {
             var semaphore = new SemaphoreSlim(1, 1);
@@ -308,7 +312,7 @@ namespace ism7mqtt
                         infoRead.Seq = NextSequenceId();
                     }
 
-                    await semaphore.WaitAsync(cancellationToken);
+                    await WaitForBundleResponseAsync(semaphore, cancellationToken);
                     await SendAsync(new TelegramBundleReq
                     {
                         AbortOnError = false,
@@ -321,9 +325,7 @@ namespace ism7mqtt
             }
 
             // Wait for the last pull response to be fully processed before subscribing.
-            // Older ISM7 hardware (HW 1.0) corrupts responses when pull and push subscribe requests overlap. So we are deferring all push subscribes until here.
-            // This restores the startup order that was present until incl. v0.0.19
-            await semaphore.WaitAsync(cancellationToken);
+            await WaitForBundleResponseAsync(semaphore, cancellationToken);
 
             // Phase 2: send push subscribes after all pulls are complete
             foreach (var (busAddress, bundleId) in pendingSubscriptions)
@@ -334,6 +336,20 @@ namespace ism7mqtt
             if (OnInitializationFinishedAsync is not null)
             {
                 await OnInitializationFinishedAsync(_config, cancellationToken);
+            }
+        }
+
+        private static async Task WaitForBundleResponseAsync(SemaphoreSlim semaphore, CancellationToken cancellationToken)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(InitialValueTimeout);
+            try
+            {
+                await semaphore.WaitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("Shutdown ism7mqtt due to timeout during startup.");
             }
         }
 

--- a/src/ism7mqtt/Program.cs
+++ b/src/ism7mqtt/Program.cs
@@ -43,6 +43,7 @@ namespace ism7mqtt
             _useSeparateTopics = GetEnvBool("ISM7_SEPARATE");
             _retain = GetEnvBool("ISM7_RETAIN");
             int interval = GetEnvInt32("ISM7_INTERVAL", 60);
+            int startupTimeout = GetEnvInt32("ISM7_STARTUP_TIMEOUT", 90);
             string discoveryId = GetEnvString("ISM7_HOMEASSISTANT_ID");
             string language = GetEnvString("ISM7_LANGUAGE", "DEU");
             var options = new OptionSet
@@ -58,6 +59,7 @@ namespace ism7mqtt
                 {"s|separate", "send values to separate mqtt topics - also disables json payload", x=> _useSeparateTopics = x != null},
                 {"retain", "retain mqtt messages", x=> _retain = x != null},
                 {"interval=", "push interval in seconds (defaults to 60)", (int x) => interval = x},
+                {"startup-timeout=", "timeout in seconds to wait for each pull request response during startup (defaults to 90)", (int x) => startupTimeout = x},
                 {"hass-id=", "HomeAssistant auto-discovery device id/entity prefix (implies --separate and --retain)", x => discoveryId = x},
                 {"l|lang=", "language for HA localization (DEU,CHN,GRC,EST,HRV,LVA,LTU,ROU,ITA,ESP,FRA,POL,CZE,SVK,RUS,DNK,HUN,GBR,TUR,NLD,BUL,POR)", x => language = x},
                 {"d|debug", "dump raw xml messages", x => enableDebug = x != null},
@@ -134,6 +136,7 @@ namespace ism7mqtt
                         var client = new Ism7Client((config, token) => OnMessage(mqttClient, config, enableDebug, token), parameter, ip, localizer)
                         {
                             Interval = interval,
+                            StartupTimeout = startupTimeout,
                             EnableDebug = enableDebug
                         };
                         mqttClient.ApplicationMessageReceivedAsync += x => OnMessage(client, x, enableDebug, cts.Token);


### PR DESCRIPTION
In case the ISM module does not response to one of the bundle pull requests at startup, ism7mqtt was waiting forever, the startup got stalled.

With this PR a conservative timeout of 90 seconds is added to each pull bundle request. If the ISM module does not response, an exception is thrown and the startup is interrupted.