### PR TITLE
Add possibility to overwrite the parameter.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Possible environmental variables:
 * ISM7_DISABLEJSON
 * ISM7_SEPARATE
 * ISM7_STARTUP_TIMEOUT
+* ISM7_PARAMETER_XML_OVERRIDE
 
 `ISM7_STARTUP_TIMEOUT` (in seconds, defaults to `90`, also available as `--startup-timeout`)
 only applies to the initial startup phase, where ism7mqtt requests all configured values from
@@ -44,6 +45,24 @@ this time, ism7mqtt assumes the connection is stuck, logs the problem and exits 
 restarted (e.g. by Docker's restart policy). Increase this value if your setup regularly needs
 more time to answer a single request; decrease it if you want ism7mqtt to fail faster on a
 stuck connection.
+
+### Advanced: overriding the built-in parameter.xml
+
+ism7mqtt ships with a built-in `parameter.xml` describing every known Wolf parameter (name, min/max, selectable values, ...). If your installation exposes values that are missing from it (e.g. an incomplete `KeyValueList` for a select parameter), you can point ism7mqtt at your own local copy instead, via `--parameter-xml-override <path>` or `ISM7_PARAMETER_XML_OVERRIDE`. This is opt-in only - if unset, behaviour is unchanged and the built-in file is used as before.
+
+> [!WARNING]
+> This **replaces** the entire built-in template, it does not merge with it. Start from a copy of the current [`parameter.xml`](src/ism7mqtt/Resources/parameter.xml) in this repo, edit only what you need, and keep it in sync when this file changes in later releases - there is no drift detection.
+
+For Docker, mount your edited file additionally to the existing `parameter.json` mount and point the new environment variable at it:
+
+```sh
+docker run -d --restart=unless-stopped \
+  -v ./parameter.json:/app/parameter.json \
+  -v ./parameter.xml:/app/parameter.xml \
+  -e ISM7_MQTTHOST=<mqttserver> -e ISM7_IP=<ism7 ip/host> -e ISM7_PASSWORD=<ism7 password> \
+  -e ISM7_PARAMETER_XML_OVERRIDE=/app/parameter.xml \
+  zivillian/ism7mqtt:latest
+```
 
 ### HomeAssistant
 

--- a/src/ism7mqtt.Tests/Fixtures/parameter-xml-override.json
+++ b/src/ism7mqtt.Tests/Fixtures/parameter-xml-override.json
@@ -1,0 +1,6 @@
+{
+  "TcpPort": {{TCP_PORT}},
+  "Devices": [
+    { "ReadBusAddress": "0x85", "WriteBusAddress": null, "DeviceTemplateId": 360000, "Parameter": [360065] }
+  ]
+}

--- a/src/ism7mqtt.Tests/Ism7ClientStartupTests.cs
+++ b/src/ism7mqtt.Tests/Ism7ClientStartupTests.cs
@@ -92,6 +92,128 @@ public class Ism7ClientStartupTests
     }
 
     [Fact]
+    public async Task ParameterXmlOverride_UsesLocalTemplateInsteadOfEmbedded()
+    {
+        // PTID 360065 ships with KeyValueList "0;Standby;1;Auto;2;Permanent;3;Sparen" (MaxValueCondition 3).
+        // The override below adds the verified cooling-mode values 6/7/8, mirroring the shape of the
+        // built-in Resources/parameter.xml entry, to prove --parameter-xml-override/ISM7_PARAMETER_XML_OVERRIDE
+        // actually replaces the embedded parameter template instead of merging with or ignoring it.
+        const string overrideXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParameterTemplateConfig>
+              <ParameterList>
+                <ListParameterDescriptor PTID="360065">
+                  <Name>Programmwahl</Name>
+                  <App>true</App>
+                  <ReadOnlyConditionId>False</ReadOnlyConditionId>
+                  <InactiveConditionId>False</InactiveConditionId>
+                  <IsSnapshotTransmitEnabled>true</IsSnapshotTransmitEnabled>
+                  <MinValueCondition>0</MinValueCondition>
+                  <MaxValueCondition>8</MaxValueCondition>
+                  <ControlType>ProgramSelectionListView</ControlType>
+                  <KeyValueList>0;Standby;1;Auto;2;Permanent;3;Sparen;6;Permanent cooling;7;Automatic heating;8;Automatic cooling</KeyValueList>
+                </ListParameterDescriptor>
+              </ParameterList>
+            </ParameterTemplateConfig>
+            """;
+        var overridePath = Path.GetTempFileName();
+        File.WriteAllText(overridePath, overrideXml);
+
+        await using var server = new FakeIsm7Server(request => RespondFromTable(request,
+            new Dictionary<ushort, (string Low, string High)> { [10100] = ("0x06", "0x00") })); // 360065 Programmwahl: 6 -> "Permanent cooling"
+        var parameterPath = TestFixtures.WriteParameterFile("parameter-xml-override.json", server.Port);
+        try
+        {
+            var captured = new List<JsonMessage>();
+            var initFinished = new TaskCompletionSource<bool>();
+            var client = new Ism7Client((config, _) =>
+            {
+                foreach (var message in config.JsonMessages)
+                {
+                    captured.Add(message);
+                }
+                return Task.CompletedTask;
+            }, parameterPath, "127.0.0.1", new Ism7Localizer("DEU"), overridePath)
+            {
+                StartupTimeout = 5,
+                OnInitializationFinishedAsync = (_, _) =>
+                {
+                    initFinished.TrySetResult(true);
+                    return Task.CompletedTask;
+                }
+            };
+
+            using var cts = new CancellationTokenSource();
+            var runTask = client.RunAsync("test-password", cts.Token);
+
+            var completed = await Task.WhenAny(initFinished.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(initFinished.Task, completed);
+
+            cts.Cancel();
+            await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+            var mkBm2 = Assert.Single(captured, m => m.Path == "Wolf/127.0.0.1/MK_BM-2_0x85");
+            Assert.Equal("Permanent cooling", mkBm2.Content["Programmwahl"]!["text"]!.GetValue<string>());
+            Assert.Equal("6", mkBm2.Content["Programmwahl"]!["value"]!.ToJsonString());
+        }
+        finally
+        {
+            File.Delete(parameterPath);
+            File.Delete(overridePath);
+        }
+    }
+
+    [Fact]
+    public async Task NoParameterXmlOverride_UsesEmbeddedTemplate()
+    {
+        // Regression guard for the new optional parameterXmlOverridePath parameter added to Ism7Client/Ism7Config
+        // for --parameter-xml-override/ISM7_PARAMETER_XML_OVERRIDE. Passes an explicit null (instead of omitting
+        // the argument, as every other test in this file does) to pin that "unset" still falls back to
+        // Resources.ParameterTemplates - LoadParameterTemplates() must never reach its File.ReadAllText branch.
+        // Deliberately asserts on PTID 360066 (Reglertyp), not 360065 (the parameter missing_cooling_360065.md
+        // is about), so this test can't start failing once that bug is eventually fixed in the embedded template.
+        await using var server = new FakeIsm7Server(request => RespondFromTable(request, HappyPathTelegrams));
+        var parameterPath = TestFixtures.WriteParameterFile("happy-path.json", server.Port);
+        try
+        {
+            var captured = new List<JsonMessage>();
+            var initFinished = new TaskCompletionSource<bool>();
+            var client = new Ism7Client((config, _) =>
+            {
+                foreach (var message in config.JsonMessages)
+                {
+                    captured.Add(message);
+                }
+                return Task.CompletedTask;
+            }, parameterPath, "127.0.0.1", new Ism7Localizer("DEU"), parameterXmlOverridePath: null)
+            {
+                StartupTimeout = 5,
+                OnInitializationFinishedAsync = (_, _) =>
+                {
+                    initFinished.TrySetResult(true);
+                    return Task.CompletedTask;
+                }
+            };
+
+            using var cts = new CancellationTokenSource();
+            var runTask = client.RunAsync("test-password", cts.Token);
+
+            var completed = await Task.WhenAny(initFinished.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(initFinished.Task, completed);
+
+            cts.Cancel();
+            await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+            var mkBm2 = Assert.Single(captured, m => m.Path == "Wolf/127.0.0.1/MK_BM-2_0x85");
+            Assert.Equal("2", mkBm2.Content["Reglertyp"]!.ToJsonString());
+        }
+        finally
+        {
+            File.Delete(parameterPath);
+        }
+    }
+
+    [Fact]
     public async Task HappyPath_ChunksLargeDeviceIntoThreePullBundles()
     {
         // Fixtures/chunked-pull.json has one device with 42 single-telegram parameters. They should be

--- a/src/ism7mqtt/ISM7/Ism7Client.cs
+++ b/src/ism7mqtt/ISM7/Ism7Client.cs
@@ -39,11 +39,11 @@ namespace ism7mqtt
 
         public Func<Ism7Config, CancellationToken, Task> OnInitializationFinishedAsync { get; set; }
 
-        public Ism7Client(Func<Ism7Config, CancellationToken, Task> messageHandler, string parameterPath, string host, Ism7Localizer localizer)
+        public Ism7Client(Func<Ism7Config, CancellationToken, Task> messageHandler, string parameterPath, string host, Ism7Localizer localizer, string parameterXmlOverridePath = null)
         {
             _messageHandler = messageHandler;
             _host = host;
-            _config = new Ism7Config(parameterPath, localizer);
+            _config = new Ism7Config(parameterPath, localizer, parameterXmlOverridePath);
             _pipe = new Pipe();
         }
 

--- a/src/ism7mqtt/ISM7/Ism7Config.cs
+++ b/src/ism7mqtt/ISM7/Ism7Config.cs
@@ -21,10 +21,12 @@ namespace ism7mqtt
         private readonly IDictionary<byte, List<RunningDevice>> _devices;
         private readonly Dictionary<string, List<InfoRead>> _bundles = new();
         private readonly ConfigRoot _config;
+        private readonly string _parameterXmlOverridePath;
 
-        public Ism7Config(string filename, Ism7Localizer localizer)
+        public Ism7Config(string filename, Ism7Localizer localizer, string parameterXmlOverridePath = null)
         {
             _localizer = localizer;
+            _parameterXmlOverridePath = parameterXmlOverridePath;
             _deviceTemplates = LoadDeviceTemplates();
             _converterTemplates = LoadConverterTemplates();
             _parameterTemplates = LoadParameterTemplates();
@@ -60,7 +62,10 @@ namespace ism7mqtt
         private List<ParameterDescriptor> LoadParameterTemplates()
         {
             var serializer = new XmlSerializer(typeof(ParameterTemplateConfig));
-            using (var reader = new StringReader(Resources.ParameterTemplates))
+            var xml = String.IsNullOrEmpty(_parameterXmlOverridePath)
+                ? Resources.ParameterTemplates
+                : File.ReadAllText(_parameterXmlOverridePath);
+            using (var reader = new StringReader(xml))
             {
                 var converter = (ParameterTemplateConfig)serializer.Deserialize(reader);
                 return converter.ParameterList;

--- a/src/ism7mqtt/Program.cs
+++ b/src/ism7mqtt/Program.cs
@@ -37,6 +37,7 @@ namespace ism7mqtt
             string ip = GetEnvString("ISM7_IP");
             string password = GetEnvString("ISM7_PASSWORD");
             string parameter = "parameter.json";
+            string parameterXmlOverride = GetEnvString("ISM7_PARAMETER_XML_OVERRIDE");
             string mqttUsername = GetEnvString("ISM7_MQTTUSERNAME");
             string mqttPassword = GetEnvString("ISM7_MQTTPASSWORD");
             _qos = (MqttQualityOfServiceLevel)GetEnvInt32("ISM7_MQTTQOS", 0);
@@ -52,6 +53,7 @@ namespace ism7mqtt
                 {"i|ipAddress=", "Wolf Hostname or IP address", x => ip = x},
                 {"p|password=", "Wolf password", x => password = x},
                 {"t|parameter=", $"path to parameter.json - defaults to {parameter}", x => parameter = x},
+                {"parameter-xml-override=", "ADVANCED: path to a local parameter.xml that replaces the built-in parameter template (use with care)", x => parameterXmlOverride = x},
                 {"mqttuser=", "MQTT username", x => mqttUsername = x},
                 {"mqttpass=", "MQTT password", x => mqttPassword = x},
                 {"mqttqos=", "MQTT QoS", (int x) => _qos = (MqttQualityOfServiceLevel)x},
@@ -87,6 +89,11 @@ namespace ism7mqtt
             if (!File.Exists(parameter))
             {
                 Console.Error.WriteLine($"'{parameter}' does not exist");
+                return;
+            }
+            if (!String.IsNullOrEmpty(parameterXmlOverride) && !File.Exists(parameterXmlOverride))
+            {
+                Console.Error.WriteLine($"'{parameterXmlOverride}' does not exist");
                 return;
             }
 
@@ -133,7 +140,7 @@ namespace ism7mqtt
                         await mqttClient.ConnectAsync(mqttOptions, cts.Token);
                         await mqttClient.SubscribeAsync($"Wolf/{ip}/+/set");
                         await mqttClient.SubscribeAsync($"Wolf/{ip}/+/set/#");
-                        var client = new Ism7Client((config, token) => OnMessage(mqttClient, config, enableDebug, token), parameter, ip, localizer)
+                        var client = new Ism7Client((config, token) => OnMessage(mqttClient, config, enableDebug, token), parameter, ip, localizer, parameterXmlOverride)
                         {
                             Interval = interval,
                             StartupTimeout = startupTimeout,


### PR DESCRIPTION
From time to time some options are missing in the `parameter.xml`. See for example issues https://github.com/zivillian/ism7mqtt/issues/231 and https://github.com/b3nn0/hassio-addon-ism7mqtt/issues/89.

As I do not want to change the original file from Wolf, I give **advanced users** the ability to overwrite the `parameter.xml` locally.
